### PR TITLE
Adds missing npm package for react-scripts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
+    "react-scripts": "^4.0.3",
     "sass": "^1.32.12",
     "stripe": "^8.148.0",
     "web-vitals": "^1.1.2"


### PR DESCRIPTION
Put the fix to address post-build step failure in prod caused by missing npm package for react-scripts.
![image](https://user-images.githubusercontent.com/13324397/117767068-122de180-b1f6-11eb-8dd5-52c3f2dadaee.png)
